### PR TITLE
added implementation merge options

### DIFF
--- a/builder/api.go
+++ b/builder/api.go
@@ -36,6 +36,12 @@ type Implementations struct {
 func (implementations *Implementations) Order() []string {
 	return implementations.implementations
 }
+// Provides the implementations as an ordered string list
+func (implementations *Implementations) Merge(merge Implementations) {
+	for _, add := range merge.Order() {
+		implementations.implementations = append(implementations.implementations, add)
+	}
+}
 
 /**
  * The BuildAPI


### PR DESCRIPTION
This patch includes a small enhancement to Builder Implementations, allowing them to merge easier.

Builder implementations are a string list of what "categories" of operations that a builder should take responsibility for.  The implementations often map 1-1 to api operations, such as config, command, orchestration, but they do not need to.