### PR TITLE
Convert builder settings to be a provider

### DIFF
--- a/builder/api.go
+++ b/builder/api.go
@@ -57,7 +57,7 @@ type BuilderAPI struct {
 func (builder *BuilderAPI) AddBuilder(hand Builder) {
 	builder.availableBuilders.Add(hand.Id(), hand)
 }
-func (builder *BuilderAPI) ActivateBuilder(id string, implementations Implementations, settings interface{}) error {
+func (builder *BuilderAPI) ActivateBuilder(id string, implementations Implementations, settings SettingsProvider) error {
 	if hand, err := builder.availableBuilders.Get(id); err == nil {
 		hand.SetAPI(api.API(builder))
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -21,7 +21,7 @@ type Builder interface {
 	// Set a API for this Handler
 	SetAPI(parent api.API)
 	// Initialize and activate the Handler
-	Activate(implementations Implementations, settings interface{}) error
+	Activate(Implementations, SettingsProvider) error
 	// Rturn a string identifier for the Handler (not functionally needed yet)
 	Id() string
 	// Return a list of Operations from the Handler

--- a/builder/settings.go
+++ b/builder/settings.go
@@ -4,6 +4,12 @@ import (
 	"errors"
 )
 
+
+// An abstracted settings provider that can unmarshal to a target
+type SettingsProvider interface {
+	AssignSettings(target interface{}) error
+}
+
 /**
  * The following 2 structs are used to keep track of settings
  * as a string map, but where each value knows from what config
@@ -11,11 +17,11 @@ import (
  */
 
 // Constructor for BuildSetting
-func New_BuildSetting(buildType string, implementations Implementations, settings interface{}) *BuildSetting {
+func New_BuildSetting(buildType string, implementations Implementations, settingsProvider SettingsProvider) *BuildSetting {
 	return &BuildSetting{
 		Type: buildType,
 		Implementations: implementations,
-		Settings: settings,
+		SettingsProvider: settingsProvider,
 	}
 }
 
@@ -23,7 +29,7 @@ func New_BuildSetting(buildType string, implementations Implementations, setting
 type BuildSetting struct {
 	Type string
 	Implementations Implementations
-	Settings interface{}
+	SettingsProvider SettingsProvider
 }
 
 // An ordered list of BuildSettings


### PR DESCRIPTION
This patch changes the core builder architecture, to pass a SettingsProvider to buidlers, instead of passing a settings interface{}.  This should make it easier to convert provided settings to particular structs in the end builders.